### PR TITLE
Remove the need for box.json to exist.

### DIFF
--- a/dumptruck_web.py
+++ b/dumptruck_web.py
@@ -240,7 +240,7 @@ def get_database_name(boxhome, box, default='scraperwiki.sqlite'):
     except IOError:
         if default:
             return default
-        raise QueryError('Error: SAFDSDFD No box.json file', code=500)
+        raise QueryError('Error: No box.json file', code=500)
 
     with fd as f:
         sw_json = f.read()

--- a/test_api.py
+++ b/test_api.py
@@ -291,9 +291,9 @@ class TestAPI(unittest.TestCase):
         self._q('scraperwiki.sqlite', 9804)
 
     def test_no_sw_json(self):
-        """Raises an error if there is no box.json."""
+        """Does not raise an an error if there is no box.json."""
         os.system('rm -f ' + SW_JSON)
-        self._q(':memory:', 2938, output_check='No box.json', code_check=500)
+        self._q(':memory:', 2938, output_check='2938', code_check=200)
 
     def test_malformed_json(self):
         """Raises an error if there is a malformed box.json."""

--- a/test_api.py
+++ b/test_api.py
@@ -251,7 +251,7 @@ class TestAPI(unittest.TestCase):
         if not os.path.isdir(JACK):
             os.makedirs(JACK)
 
-        dbname = os.path.join(JACK, os.path.expanduser(dbname))
+        dbname = os.path.expanduser(dbname)
         dt = dumptruck.DumpTruck(dbname)
         dt.drop('bacon', if_exists=True)
         dt.insert({'p': p}, 'bacon')
@@ -278,7 +278,7 @@ class TestAPI(unittest.TestCase):
     def test_dumptruck(self):
         """Works with ordinary file."""
         os.system('cp fixtures/sw.json.dumptruck.db ' + SW_JSON)
-        self._q('dumptruck.db', 2124)
+        self._q('~/dumptruck.db', 2124)
 
     def test_home_dumptruck(self):
         """Uses database found in home directory."""
@@ -288,12 +288,16 @@ class TestAPI(unittest.TestCase):
     def test_scraperwiki(self):
         """Can use other popular database filenames."""
         os.system('cp fixtures/sw.json.scraperwiki.sqlite ' + SW_JSON)
-        self._q('scraperwiki.sqlite', 9804)
+        self._q('~/scraperwiki.sqlite', 9804)
 
-    def test_no_sw_json(self):
-        """Does not raise an an error if there is no box.json."""
+    def test_default_sqlite(self):
+        """When no box.json uses scraperwiki.sqlite as a
+        default."""
+
+        # Remove the box.json file.
         os.system('rm -f ' + SW_JSON)
-        self._q(':memory:', 2938, output_check='2938', code_check=200)
+        self._q('scraperwiki.sqlite', 2938,
+          output_check='2938', code_check=200)
 
     def test_malformed_json(self):
         """Raises an error if there is a malformed box.json."""


### PR DESCRIPTION
Before this change `box.json` was required for the sql endpoint to work on cobalt.

Now `box.json` isn't required, and a default of `scraperwiki.sqlite` will be used.
