### PR TITLE
Fix default database directory

### DIFF
--- a/dumptruck_web.py
+++ b/dumptruck_web.py
@@ -239,7 +239,7 @@ def get_database_name(boxhome, box, default='scraperwiki.sqlite'):
         fd = open(path)
     except IOError:
         if default:
-            return default
+            return os.path.join(boxhome, box, default)
         raise QueryError('Error: No box.json file', code=500)
 
     with fd as f:

--- a/test_api.py
+++ b/test_api.py
@@ -296,7 +296,7 @@ class TestAPI(unittest.TestCase):
 
         # Remove the box.json file.
         os.system('rm -f ' + SW_JSON)
-        self._q('scraperwiki.sqlite', 2938,
+        self._q('~/scraperwiki.sqlite', 2938,
           output_check='2938', code_check=200)
 
     def test_malformed_json(self):


### PR DESCRIPTION
Before, it would default to looking for the database in the current
directory if no box.json. Now it defaults to looking in the correct box
home, box specified directory.
